### PR TITLE
disable s3cmd's broken 'mime magic'. PMT #101777

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,5 +9,4 @@ deploy:
 	/usr/local/bin/hugo -s . -b 'https://flgstatic.stage.ccnmtl.columbia.edu/' \
 	&& mv public/json/all/index.html public/js/all.json \
 	&& ./checkjson.py \
-	&& s3cmd --acl-public --delete-removed --no-progress sync public/* s3://flgstatic.stage.ccnmtl.columbia.edu/ \
-  && s3cmd --acl-public -m text/css sync public/css/* s3://flgstatic.stage.ccnmtl.columbia.edu/css/
+	&& s3cmd --acl-public --delete-removed --no-progress --no-mime-magic --guess-mime-type sync public/* s3://flgstatic.stage.ccnmtl.columbia.edu/


### PR DESCRIPTION
instead just use simple file extension based mime type guessing.

see: https://github.com/s3tools/s3cmd/issues/198