### PR TITLE
iOS does not like loadeddata, prefers loadedmetadate

### DIFF
--- a/static/js/srcswap.js
+++ b/static/js/srcswap.js
@@ -20,7 +20,7 @@
         var isPaused = this.vplayer.paused();
         this.vplayer.src(this.sources[inactiveIdx]);
          var self = this;
-        this.vplayer.on('loadeddata', function(){ 
+        this.vplayer.on('loadedmetadata', function(){ 
             self.vplayer.currentTime(tc);
         });
         this.vplayer.play();


### PR DESCRIPTION
This is not in the video player branch, but it's a minor fix