### PR TITLE
Added term summary to content that requires it, not from summary

### DIFF
--- a/content/term/180-degree-rule.md
+++ b/content/term/180-degree-rule.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:48:51+01:00'
 term: 180-degree-rule
 title: 180-Degree Rule
+termsummary: 'The 180-degree rule of shooting and editing keeps the camera on one side of the action.'
 ---
 
 The 180-degree rule of shooting and [editing](../editing/) keeps the

--- a/content/term/3-d-film.md
+++ b/content/term/3-d-film.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:28:35+01:00'
 term: 3-d-film
 title: 3-D Film
+termsummary: '3-D film has a three-dimensional, stereoscopic form, creating the illusion of depth.'
 ---
 
 With competition from television and other leisure activities

--- a/content/term/aerial-shot.md
+++ b/content/term/aerial-shot.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:28:35+01:00'
 term: aerial-shot
 title: Aerial Shot
+termsummary: ''
 relatedterms:
 - Establishing Shot
 ---

--- a/content/term/aspect-ratio.md
+++ b/content/term/aspect-ratio.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:28:35+01:00'
 term: aspect-ratio
 title: Aspect Ratio
+termsummary: ''
 ---
 
 Aspect ratio refers to how the image appears on the screen based on

--- a/content/term/black-and-white-film.md
+++ b/content/term/black-and-white-film.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:28:35+01:00'
 term: black-and-white-film
 title: Black-and-White Film
+termsummary: ''
 relatedterms:
 - Cinematography
 - Color Film

--- a/content/term/camera-angle.md
+++ b/content/term/camera-angle.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:28:36+01:00'
 term: camera-angle
 title: Camera Angle
+termsummary: ''
 relatedterms:
 - Canted Angle (Dutch Angle)
 - Cinematography
@@ -10,10 +11,10 @@ relatedterms:
 ---
 
 Camera angle refers to where the camera is placed in relation to the
-subject of the image. In general, the camera is placed approximately
+subject of the image.<!--more--> In general, the camera is placed approximately
 at eye level, or up to six feet off the ground.
 
-<!--more-->
+
 
 [Low angle](../lowangle-shot/) refers to when the camera is placed
 below eye level. The viewer is therefore looking up at the subject.

--- a/content/term/camera-movement.md
+++ b/content/term/camera-movement.md
@@ -2,6 +2,7 @@
 date: '2015-02-03T11:18:31+01:00'
 term: camera-movement
 title: Camera Movement
+termsummary: ''
 relatedterms:
 - Circular Pan
 - Crane Shot
@@ -15,9 +16,7 @@ relatedterms:
 - Zoom Shot
 ---
 
-Camera movement refers to the actual or perceived physical movement of the camera apparatus through space. At its most basic level, camera movement creates a sensation in the spectator that he or she is moving through space.
-
-<!--more-->
+Camera movement refers to the actual or perceived physical movement of the camera apparatus through space.<!--more--> At its most basic level, camera movement creates a sensation in the spectator that he or she is moving through space.
 
 ### Early Development
 

--- a/content/term/canted-angle-dutch-angle.md
+++ b/content/term/canted-angle-dutch-angle.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:28:36+01:00'
 term: canted-angle-dutch-angle
 title: Canted Angle (Dutch Angle)
+termsummary: ''
 relatedterms:
 - Camera Angle
 - Camera Movement

--- a/content/term/celluloid.md
+++ b/content/term/celluloid.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:28:36+01:00'
 term: celluloid
 title: Celluloid
+termsummary: ''
 ---
 
 Cellulose nitrate was the original transparent material used as a base

--- a/content/term/chiaroscuro.md
+++ b/content/term/chiaroscuro.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:28:36+01:00'
 term: chiaroscuro
 title: Chiaroscuro
+termsummary: 'Chiaroscuro refers to strong contrasts between light and dark.'
 relatedterms:
 - Black-and-White Film
 - Cinematography

--- a/content/term/cinema-verite.md
+++ b/content/term/cinema-verite.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:28:37+01:00'
 term: cinema-verite
 title: "Cinema Verit\xE9"
+termsummary: 'Cinema verité is a French term that means "true cinema" or "cinema truth."'
 ---
 
 Also referred to as free cinema or direct cinema, cinema verité is a

--- a/content/term/cinematography.md
+++ b/content/term/cinematography.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:28:55+01:00'
 term: cinematography
 title: Cinematography
+termsummary: 'Derived from the French word cinématographe, cinematography literally means "writing in movement" and is generally understood as the art and process of capturing visual images with a camera for cinema.'
 relatedterms:
 - Black-and-White Film
 - Camera Angle

--- a/content/term/cinerama.md
+++ b/content/term/cinerama.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:28:55+01:00'
 term: cinerama
 title: Cinerama
+termsummary: 'Cinerama is a process of simultaneous filming by three cameras. The cameras are pointed at different angles and are then projected by three synchronized projectors and shown on a curved screen.'
 ---
 
 Facing an economic challenge from television in the 1950s, Hollywood

--- a/content/term/circular-pan.md
+++ b/content/term/circular-pan.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:28:56+01:00'
 term: circular-pan
 title: Circular Pan
+termsummary: 'A circular pan is a shot in which the camera rotates 360 degrees around a fixed axis.'
 relatedterms:
 - Camera Movement
 ---

--- a/content/term/clapboard-slateboard.md
+++ b/content/term/clapboard-slateboard.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:28:56+01:00'
 term: clapboard-slateboard
 title: Clapboard (Slateboard)
+termsummary: 'Before each take, a clapboard appears in front of the camera, with the number of the take written on it.'
 relatedterms:
 - Take
 ---

--- a/content/term/close-up.md
+++ b/content/term/close-up.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:28:56+01:00'
 term: close-up
 title: Close-Up
+termsummary: ''
 relatedterms:
 - Cinematography
 ---

--- a/content/term/color-film.md
+++ b/content/term/color-film.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:28:56+01:00'
 term: color-film
 title: Color Film
+termsummary: ''
 relatedterms:
 - Black-and-White Film
 - Cinematography

--- a/content/term/crane-shot.md
+++ b/content/term/crane-shot.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:28:56+01:00'
 term: crane-shot
 title: Crane Shot
+termsummary: 'A crane shot is achieved by a camera mounted on a platform, which is connected to a mechanical arm that can lift the platform up, bring it down, or move it laterally across space.'
 relatedterms:
 - Aerial Shot
 - Camera Movement

--- a/content/term/day-for-night.md
+++ b/content/term/day-for-night.md
@@ -2,12 +2,13 @@
 date: '2015-03-20T13:28:57+01:00'
 term: day-for-night
 title: Day for Night
+termsummary: ''
 relatedterms:
 - Lighting
 ---
 
 Day for night refers to the creation of a night effect while shooting
 during the day, through the manipulation of filters, underexposure, or
-printing. Day for night is usually employed for financial reasons, as
+printing.<!--more--> Day for night is usually employed for financial reasons, as
 night shooting (or night-for-night shooting) can be more expensive to
 set up.

--- a/content/term/deep-focus.md
+++ b/content/term/deep-focus.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:28:57+01:00'
 term: deep-focus
 title: Deep Focus
+termsummary: 'Deep focus is a style or technique of cinematography and staging with great depth of field, using relatively wide-angle lenses and small lens apertures to render in sharp focus near and distant planes simultaneously.'
 relatedterms:
 - Depth of Field
 - Long Take
@@ -17,8 +18,6 @@ lenses](../wideangle-lens/) and small lens apertures to render in
 sharp focus near and distant planes simultaneously. A deep-focus shot
 includes foreground, middle-ground, and extreme-background objects,
 all in focus.
-
-<!--more-->
 
 {{< embed_clip "Negative Review" >}}
 

--- a/content/term/depth-of-field.md
+++ b/content/term/depth-of-field.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:28:57+01:00'
 term: depth-of-field
 title: Depth of Field
+termsummary: ''
 relatedterms:
 - Cinematography
 - Deep Focus
@@ -13,7 +14,7 @@ relatedterms:
 
 Depth of field is the area, range of distance, or field (between the
 nearest and farthest planes) in which the elements captured in a
-camera image appear in sharp focus; depth of field is connected to
+camera image appear in sharp focus.<!--more--> Depth of field is connected to
 focus but should not be confused with it.
 
 <!--more-->

--- a/content/term/dialogue.md
+++ b/content/term/dialogue.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:28:57+01:00'
 term: dialogue
 title: Dialogue
+termsummary: ''
 relatedterms:
 - Sound
 ---

--- a/content/term/diegesis.md
+++ b/content/term/diegesis.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:28:58+01:00'
 term: diegesis
 title: Diegesis
+termsummary: ''
 relatedterms:
 - Diegetic Sound
 - Non-Diegetic Sound

--- a/content/term/diegetic-sound.md
+++ b/content/term/diegetic-sound.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:28:58+01:00'
 term: diegetic-sound
 title: Diegetic Sound
+termsummary: ''
 relatedterms:
 - Diegesis
 - Non-Diegetic Sound

--- a/content/term/dissolve.md
+++ b/content/term/dissolve.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:28:58+01:00'
 term: dissolve
 title: Dissolve
+termsummary: ''
 relatedterms:
 - Editing
 ---

--- a/content/term/dolly-dolly-shot.md
+++ b/content/term/dolly-dolly-shot.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:28:58+01:00'
 term: dolly-dolly-shot
 title: Dolly (Dolly Shot)
+termsummary: ''
 relatedterms:
 - Camera Movement
 ---

--- a/content/term/double-multiple-exposure.md
+++ b/content/term/double-multiple-exposure.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:28:58+01:00'
 term: double-multiple-exposure
 title: Double (Multiple) Exposure
+termsummary: ''
 ---
 
 Double exposure is the superimposition of two images, one over the

--- a/content/term/editing.md
+++ b/content/term/editing.md
@@ -2,6 +2,7 @@
 date: '2015-02-03T11:44:40+01:00'
 term: editing
 title: Editing
+termsummary: ''
 relatedterms:
 - Eye-Line Match
 - Fade

--- a/content/term/establishing-shot.md
+++ b/content/term/establishing-shot.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:28:59+01:00'
 term: establishing-shot
 title: Establishing Shot
+termsummary: ''
 relatedterms:
 - Aerial Shot
 ---

--- a/content/term/exposure.md
+++ b/content/term/exposure.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:28:59+01:00'
 term: exposure
 title: Exposure
+termsummary: ''
 relatedterms:
 - Cinematography
 ---

--- a/content/term/eye-line-match.md
+++ b/content/term/eye-line-match.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:28:59+01:00'
 term: eye-line-match
 title: Eye-Line Match
+termsummary: ''
 relatedterms:
 - Editing
 ---

--- a/content/term/fade.md
+++ b/content/term/fade.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:28:59+01:00'
 term: fade
 title: Fade
+termsummary: ''
 relatedterms:
 - Editing
 ---

--- a/content/term/fisheye-lens.md
+++ b/content/term/fisheye-lens.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:29:00+01:00'
 term: fisheye-lens
 title: Fisheye Lens
+termsummary: 'A fisheye lens is a wide-angle lens that takes in a nearly 180-degree field of view.'
 relatedterms:
 - Cinematography
 ---

--- a/content/term/frames-per-second.md
+++ b/content/term/frames-per-second.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:29:00+01:00'
 term: frames-per-second
 title: Frames-per-Second
+termsummary: ''
 relatedterms:
 - Slow Motion
 ---

--- a/content/term/freeze-frame.md
+++ b/content/term/freeze-frame.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:29:00+01:00'
 term: freeze-frame
 title: Freeze-Frame
+termsummary: ''
 relatedterms:
 - Cinematography
 ---

--- a/content/term/handheld-shot.md
+++ b/content/term/handheld-shot.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:29:00+01:00'
 term: handheld-shot
 title: Handheld Shot
+termsummary: ''
 relatedterms:
 - Camera Movement
 - Steadicam Shot

--- a/content/term/high-angle-shot.md
+++ b/content/term/high-angle-shot.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:29:00+01:00'
 term: high-angle-shot
 title: High-Angle Shot
+termsummary: ''
 relatedterms:
 - Camera Angle
 - Cinematography

--- a/content/term/iris-shot.md
+++ b/content/term/iris-shot.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:29:01+01:00'
 term: iris-shot
 title: Iris Shot
+termsummary: 'The iris shot is a shot masked in a circular form.'
 relatedterms:
 - Cinematography
 ---

--- a/content/term/jump-cut.md
+++ b/content/term/jump-cut.md
@@ -2,12 +2,13 @@
 date: '2015-02-03T11:54:14+01:00'
 term: jump-cut
 title: Jump Cut
+termsummary: ''
 relatedterms:
 - Editing
 ---
 
 A jump cut is an editing technique in which some frames are taken out
-of a sequence. This is typically used to draw the audience's attention
-to the conventions of filmmaking.<!--more-->
+of a sequence.<!--more--> This is typically used to draw the audience's attention
+to the conventions of filmmaking.
 
 {{< embed_clip "Lunch Date" >}}

--- a/content/term/lighting.md
+++ b/content/term/lighting.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:29:01+01:00'
 term: lighting
 title: Lighting
+termsummary: ''
 ---
 
 Lighting is responsible for the quality of a film's images and often a

--- a/content/term/long-shot.md
+++ b/content/term/long-shot.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:29:01+01:00'
 term: long-shot
 title: Long Shot
+termsummary: 'A long shot shows characters in their entirety, as well as some of the surrounding environment.'
 ---
 
 Generally used as an establishing shot that begins a film or sequence,

--- a/content/term/long-take.md
+++ b/content/term/long-take.md
@@ -2,6 +2,7 @@
 date: '2015-02-03T11:50:49+01:00'
 term: long-take
 title: Long Take
+termsummary: 'The long take is a shot of some duration.'
 ---
 
 The long take, a shot of some duration, was not an aesthetic choice

--- a/content/term/low-angle-shot.md
+++ b/content/term/low-angle-shot.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:29:01+01:00'
 term: low-angle-shot
 title: Low-Angle Shot
+termsummary: ''
 ---
 
 A low-angle shot is achieved when the camera is placed below eye

--- a/content/term/medium-shot.md
+++ b/content/term/medium-shot.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:29:02+01:00'
 term: medium-shot
 title: Medium Shot
+termsummary: ''
 ---
 
 A medium shot is one that can include several characters in a frame,

--- a/content/term/mise-en-scene.md
+++ b/content/term/mise-en-scene.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:29:02+01:00'
 term: mise-en-scene
 title: "Mise-en-Sc\xE8ne"
+termsummary: 'Mise-en-scène originated in the theater and is used in film to refer to everything that goes into the composition of a shot--framing, movement of the camera and characters, lighting, set design and the visual environment, and sound.'
 ---
 
 Literally translated as "staging in action," mise-en-scène originated

--- a/content/term/montage.md
+++ b/content/term/montage.md
@@ -2,6 +2,7 @@
 date: '2015-02-03T11:39:17+01:00'
 term: montage
 title: Montage
+termsummary: 'At the core of montage is the idea that a single shot has meaning only in relation to another shot.'
 relatedterms:
 - Editing
 ---
@@ -10,7 +11,7 @@ Taken from the French word *monter*, meaning "to assemble," this process
 of [editing](../editing/) was developed in the theories and films of the Soviet
 directors Pudovkin, Eisenstein, and Vertov. At the core of montage was
 the idea that a single shot has meaning only in relation to another
-shot.<!--more-->
+shot.
 
 {{< embed_clip "Odessa Steps" >}}
 

--- a/content/term/non-diegetic-sound.md
+++ b/content/term/non-diegetic-sound.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:29:02+01:00'
 term: non-diegetic-sound
 title: Non-Diegetic Sound
+termsummary: ''
 relatedterms:
 - Diegesis
 - Diegetic Sound

--- a/content/term/pan-shot.md
+++ b/content/term/pan-shot.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:29:02+01:00'
 term: pan-shot
 title: Pan Shot
+termsummary: ''
 relatedterms:
 - Camera Movement
 ---

--- a/content/term/parallel-editing.md
+++ b/content/term/parallel-editing.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:29:02+01:00'
 term: parallel-editing
 title: Parallel Editing
+termsummary: ''
 relatedterms:
 - Editing
 ---

--- a/content/term/point-of-view.md
+++ b/content/term/point-of-view.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:29:03+01:00'
 term: point-of-view
 title: Point of View
+termsummary: 'With POV, the audience is, in effect, looking through the character’s eye.'
 relatedterms:
 - Eye-Line Match
 ---

--- a/content/term/rear-projection.md
+++ b/content/term/rear-projection.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:29:03+01:00'
 term: rear-projection
 title: Rear Projection
+termsummary: ''
 ---
 
 Rear projection involves the projection of either a still or a moving

--- a/content/term/shot-scene-and-sequence.md
+++ b/content/term/shot-scene-and-sequence.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:29:03+01:00'
 term: shot-scene-and-sequence
 title: Shot, Scene, and Sequence
+termsummary: 'A shot consists of a single take. A scene is composed of several shots. A sequence is composed of scenes.'
 ---
 
 A shot consists of a single take, which can be several seconds or

--- a/content/term/slow-motion.md
+++ b/content/term/slow-motion.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:29:03+01:00'
 term: slow-motion
 title: Slow Motion
+termsummary: 'Slow motion is typically achieved by shooting at a fast speed and then projecting at a normal speed.'
 relatedterms:
 - Frames-per-Second
 ---

--- a/content/term/sound.md
+++ b/content/term/sound.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:29:04+01:00'
 term: sound
 title: Sound
+termsummary: ''
 relatedterms:
 - Dialogue
 - Diegetic Sound

--- a/content/term/soundtrack.md
+++ b/content/term/soundtrack.md
@@ -2,12 +2,13 @@
 date: '2015-03-20T13:29:04+01:00'
 term: soundtrack
 title: Soundtrack
+termsummary: ''
 relatedterms:
 - Sound
 ---
 
-Soundtrack refers to all the audio elements of a film--dialogue, music, sound effects, etc. However, it is more commonly associated with the music, or collection of songs, heard during a film. 
+Soundtrack refers to all the audio elements of a film--dialogue, music, sound effects, etc.<!--more--> However, it is more commonly associated with the music, or collection of songs, heard during a film. 
 
-<!--more-->
+
 
 {{< embed_clip "Rescue of Gasim" >}}

--- a/content/term/split-screen.md
+++ b/content/term/split-screen.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:29:04+01:00'
 term: split-screen
 title: Split Screen
+termsummary: ''
 relatedterms:
 - Wipe
 ---

--- a/content/term/steadicam-shot.md
+++ b/content/term/steadicam-shot.md
@@ -2,6 +2,7 @@
 date: '2015-02-03T11:56:59+01:00'
 term: steadicam-shot
 title: Steadicam Shot
+termsummary: 'A Steadicam shot employs a kind of special hydraulic harness that smoothes out the bumps and jerkiness associated with the typical handheld style.'
 relatedterms:
 - Camera Movement
 - Handheld Shot

--- a/content/term/superimposition.md
+++ b/content/term/superimposition.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:29:04+01:00'
 term: superimposition
 title: Superimposition
+termsummary: ''
 ---
 
 Superimposition is when two or more image are placed over each other

--- a/content/term/swish-pan.md
+++ b/content/term/swish-pan.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:29:04+01:00'
 term: swish-pan
 title: Swish Pan
+termsummary: ''
 relatedterms:
 - Camera movement
 - Editing

--- a/content/term/take.md
+++ b/content/term/take.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:29:05+01:00'
 term: take
 title: Take
+termsummary: ''
 relatedterms:
 - Clapboard (Slateboard)
 ---

--- a/content/term/virtual-camera-movement.md
+++ b/content/term/virtual-camera-movement.md
@@ -2,6 +2,7 @@
 date: '2015-02-02T17:00:36+01:00'
 term: virtual-camera-movement
 title: Virtual Camera Movement
+termsummary: 'Virtual camera movement refers to the creation of the perceptual sense of movement through space by the manipulation of focal length or by more irregular techniques.'
 relatedterms:
 - Camera Movement
 ---

--- a/content/term/voice-over.md
+++ b/content/term/voice-over.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:29:05+01:00'
 term: voice-over
 title: Voice-Over
+termsummary: ''
 relatedterms:
 - Sound
 ---

--- a/content/term/wide-angle-lens.md
+++ b/content/term/wide-angle-lens.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:29:05+01:00'
 term: wide-angle-lens
 title: Wide-Angle Lens
+termsummary: 'A wide-angle lens has a short focal length, increasing the depth of field for a shot and thereby keeping in focus both the foreground and the background.'
 relatedterms:
 - Cinematography
 - Deep Focus

--- a/content/term/wide-angle-shot.md
+++ b/content/term/wide-angle-shot.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:29:05+01:00'
 term: wide-angle-shot
 title: Wide-Angle Shot
+termsummary: ''
 relatedterms:
 - Cinematography
 - Deep Focus

--- a/content/term/wipe.md
+++ b/content/term/wipe.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:29:06+01:00'
 term: wipe
 title: Wipe
+termsummary: 'Wipes allow one scene to effectively erase the previous scene and replace it.'
 relatedterms:
 - Editing
 - Split Screen

--- a/content/term/zoom-shot.md
+++ b/content/term/zoom-shot.md
@@ -2,6 +2,7 @@
 date: '2015-03-20T13:29:06+01:00'
 term: zoom-shot
 title: Zoom Shot
+termsummary: 'A zoom shot is one that permits the cinematographer to change the distance between the camera and the object being filmed without actually moving the camera.'
 relatedterms:
 - Camera Movement
 - Cinematography

--- a/layouts/section/term.html
+++ b/layouts/section/term.html
@@ -6,7 +6,7 @@
 {{ range .Data.Pages.ByTitle }}
 <p>
 <a href="{{.Permalink}}">{{.Title}}</a><br />
-{{ .Summary }}
+{{ if .Params.termsummary }}<p>{{.Params.termsummary }}</p>{{else}}{{.Summary}}{{ end }}
 </p>
 {{ end }}
 


### PR DESCRIPTION
Some terms have summary different from the first few lines of the first paragraph. Some terms have images as the first paragraph, therefore term index listed those images too, which is not the behavior wanted. So, I just created another field 'termsummary'