### PR TITLE
Use bootstrap 3.3.4 javascript to match bootstrap css version

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -12,7 +12,7 @@
 </div>
     <!-- Bootstrap core JavaScript
     ================================================== -->
-    <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.2/js/bootstrap.min.js"></script>
+    <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
     <!-- IE10 viewport hack for Surface/desktop Windows 8 bug
     <script src="../../assets/js/ie10-viewport-bug-workaround.js"></script> -->
     <script src="https://vjs.zencdn.net/4.12/video.js"></script>


### PR DESCRIPTION
FLG is using bootstrap v3.3.4 css and 3.3.2 javascript. This changes the javascript include so these versions are matching.