### PR TITLE
support Hugo 0.16

### DIFF
--- a/content/clip/shoot-out.md
+++ b/content/clip/shoot-out.md
@@ -2,7 +2,7 @@
 clipterms:
 - Wide-Angle Lens
 commentary: ''
-date: 
+date: '2015-03-20T11:35:19+01:00'
 director_first: Wong
 director_last: Kar-wai
 film: Fallen Angels

--- a/content/clip/waking-up.md
+++ b/content/clip/waking-up.md
@@ -2,7 +2,7 @@
 clipterms:
 - Wide-Angle Lens
 commentary: ''
-date: 
+date: '2015-03-20T11:35:19+01:00'
 director_first: Terry
 director_last: Gilliam
 film: 12 Monkeys


### PR DESCRIPTION
Hugo 0.16 is unhappy with empty date fields. Just filled them in with
timestamps from one of the other clips. We don't actually use the date
for anything, so it doesn't need to be super accurate.